### PR TITLE
Fix syntax for regex replacement pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-sportsdata",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-sportsdata",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "moment": "~2.0.0",
         "sprintf-js": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-sportsdata",
   "description": "A wrapper for the SportsData API",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "homepage": "https://github.com/pac12/node-sportsdata",
   "author": {
     "name": "PAC-12",

--- a/src/lib/v7/v7.coffee
+++ b/src/lib/v7/v7.coffee
@@ -16,7 +16,7 @@ class V7 extends SportApi
     this.getResource '/seasons/%(year)s/%(season)s/standings/season.xml', params, callback
 
   getGameStatistics: (params, callback) ->
-    this.getResource '/games/%(gameId)s/statistics.xml', params, callback
+    this.getResource '/games/%(gameId)s/%statistics.xml', params, callback
 
   getPlayByPlay: (params, callback) ->
     this.getResource '/games/%(gameId)s/pbp.xml', params, callback


### PR DESCRIPTION
Looks like this replacement pattern got updated a couple of weeks ago and is causing issues for the scores app when it tries to access the statistics endpoint. This fixes that issue. Will also need to release an update to the Sports app with the updated package version.