### PR TITLE
Override the year calculation for ncaamb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-sportsdata",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-sportsdata",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "moment": "~2.0.0",
         "sprintf-js": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-sportsdata",
   "description": "A wrapper for the SportsData API",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "homepage": "https://github.com/pac12/node-sportsdata",
   "author": {
     "name": "PAC-12",

--- a/src/lib/v7/ncaamb.coffee
+++ b/src/lib/v7/ncaamb.coffee
@@ -3,5 +3,40 @@ V7 = require './v7'
 class NCAAMBv7 extends V7
   league: 'ncaamb'
 
+  getYearWeekParams: (params, callback) ->
+    if typeof params is 'function'
+      callback = params
+      params = {}
+    if not params
+      params = {}
+    if not params.week
+      week = new Date()
+      week.setHours(0,0,0)
+      week.setDate(week.getDate()+1-(week.getDay()||7))
+      week = Math.ceil((((week-new Date(week.getFullYear(),0,1))/8.64e7)+1)/7)
+      if week < 10
+        seasonWeek = (week + 52) - 34
+      else if week < 35
+        seasonWeek = 1
+      else
+        seasonWeek = week - 34
+      params.week = seasonWeek
+
+    if not params.year
+      now = new Date()
+      year = now.getFullYear()
+      start = new Date(now.getFullYear(),0,0)
+      diff = now - start
+      oneDay = 1000 * 60 * 60 * 24
+      day = Math.floor(diff / oneDay)
+      if day > 180
+        params.year = year
+      else
+        params.year = year - 1
+    if not params.poll_type
+      params.poll_type = 'AP25'
+
+    [params]
+
 
 module.exports = NCAAMBv7


### PR DESCRIPTION
Looks like when we bumped basketball up to use v7 of the sportsradar api we started using the generic `getYearWeekParams` method when calculating the year to poll rankings for. This overrides that method specifically for basketball using the old v3 logic.